### PR TITLE
Re-render when nested properties are updated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,21 @@
   "version": "0.0.1",
   "description": "Convert react components to native Web Components that work with CanJS.",
   "main": "react-to-can-webcomponent",
-  "dependencies": {},
+  "dependencies": {
+    "can-observation": "^4.2.0"
+  },
   "devDependencies": {
     "@webcomponents/custom-elements": "^1.2.4",
-    "can-stache": "^4.17.20",
+    "can-observable-array": "^1.0.6",
+    "can-observable-object": "^1.0.1",
+    "can-stache": "^4.17.21",
     "can-stache-bindings": "^4.10.9",
-    "preact": "^8.5.2",
+    "preact": "^8.5.3",
     "preact-compat": "^3.19.0",
     "prop-types": "^15.7.2",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "steal": "^2.2.2",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "steal": "^2.2.4",
     "steal-qunit": "^2.0.0",
     "steal-tools": "^2.2.2"
   },
@@ -24,7 +28,8 @@
     "postpublish": "git push --tags && git checkout master && git branch -D release && git push origin master",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "release:major": "npm version major && npm publish",
+    "test": "testee --browsers firefox test.html"
   },
   "repository": {
     "type": "git",

--- a/react-to-webcomponent.js
+++ b/react-to-webcomponent.js
@@ -1,6 +1,8 @@
+import Observation from "can-observation";
 var reactComponentSymbol = Symbol.for("r2wc.reactComponent");
 var renderSymbol = Symbol.for("r2wc.reactRender");
 var shouldRenderSymbol = Symbol.for("r2wc.shouldRender");
+var observationSymbol = Symbol.for("r2wc.observation");
 
 var define = {
 	// Creates a getter/setter that re-renders everytime a property is set.
@@ -72,8 +74,17 @@ export default function(ReactComponent, React, ReactDOM) {
 		// Once connected, it will keep updating the innerHTML.
 		// We could add a render method to allow this as well.
 		this[shouldRenderSymbol] = true;
-		this[renderSymbol]();
+		// Also catch any sub-properties of observables which
+		//   are read while rendering the React component.
+		this[observationSymbol] = new Observation(() => {
+			this[renderSymbol]();
+		});
+		this[observationSymbol].on();
 	};
+	targetPrototype.disconnectedCallback = function() {
+		this[observationSymbol].off();
+	};
+
 	targetPrototype[renderSymbol] = function() {
 		if (this[shouldRenderSymbol] === true) {
 			var data = {};


### PR DESCRIPTION
This fix uses an observation when rendering the React component to listen for reads of observable properties.  When a read property changes, it triggers the rerender of the React component.

Fixes #1 