### PR TITLE
Use ylem's useObserver() to solve issues with observations and ReactDom render timing

### DIFF
--- a/lib/can-observer.js
+++ b/lib/can-observer.js
@@ -1,0 +1,94 @@
+import canReflect from 'can-reflect';
+import ObservationRecorder from 'can-observation-recorder';
+import recorderHelpers from 'can-observation/recorder-dependency-helpers';
+import queues from 'can-queues';
+
+ObservationRecorder.resume = function resume(deps) {
+  ObservationRecorder.stack.push(deps);
+};
+
+let ORDER;
+let weLeftSomethingOnTheStack = false;
+
+export default class Observer {
+  constructor(onUpdate) {
+    this.newDependencies = ObservationRecorder.makeDependenciesRecorder();
+    this.oldDependencies = null;
+    this.onUpdate = onUpdate;
+
+    this.onDependencyChange = (newVal, oldVal) => {
+      this.dependencyChange(newVal, oldVal);
+    };
+  }
+
+  startRecording() {
+    if (weLeftSomethingOnTheStack) {
+      const deps = ObservationRecorder.stop();
+      weLeftSomethingOnTheStack = false;
+
+      if (!deps.ylem) {
+        throw new Error(
+          'If you see this error with another error, clearing that should solve this. If you see ' +
+            'this error alone, please open and issue on our github and tag Christopher and Justin.'
+        );
+      }
+    }
+
+    this.oldDependencies = this.newDependencies;
+    this.nextDependencies = ObservationRecorder.start();
+    this.nextDependencies.ylem = true;
+    weLeftSomethingOnTheStack = true;
+
+    if (this.order !== undefined) {
+      ORDER = this.order;
+    } else if (ORDER !== undefined) {
+      this.order = ORDER;
+      ORDER += 1;
+    } else {
+      // the root component
+      ORDER = 0;
+      this.order = ORDER;
+    }
+  }
+
+  stopRecording() {
+    if (weLeftSomethingOnTheStack) {
+      const deps = ObservationRecorder.stop();
+      weLeftSomethingOnTheStack = false;
+
+      if (!deps.ylem) {
+        throw new Error(
+          'If you see this error with another error, clearing that should solve this. If you see ' +
+            'this error alone, please open and issue on our github and tag Christopher and Justin.'
+        );
+      }
+    }
+
+    this.newDependencies = this.nextDependencies;
+    recorderHelpers.updateObservations(this);
+  }
+
+  dependencyChange() {
+    queues.deriveQueue.enqueue(this.onUpdate, this, [], {
+      priority: this.order,
+    });
+  }
+
+  teardown() {
+    recorderHelpers.stopObserving(this.newDependencies, this.onDependencyChange);
+    queues.deriveQueue.dequeue(this.onUpdate);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  ignore(fn) {
+    return ObservationRecorder.ignore(fn)();
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  canReflect.assignSymbols(Observer.prototype, {
+    'can.getName': function getName() {
+      return `${canReflect.getName(this.constructor)}<${canReflect.getName(this.onUpdate)}>`;
+    },
+  });
+}

--- a/lib/use-observer.js
+++ b/lib/use-observer.js
@@ -1,0 +1,26 @@
+import Observer from './can-observer';
+
+// Unlike the ylem version, this hook is passed a 
+//   React instance so it can be used seamlessly
+//   by Preact et al.
+export default function useObserver(React) {
+	const { useEffect, useLayoutEffect, useState, useRef } = React;
+
+
+  const [, update] = useState();
+
+  const observer = useRef(new Observer(() => update({})));
+
+  observer.current.startRecording();
+  useLayoutEffect(() => {
+    observer.current.stopRecording();
+  });
+
+  // eslint-disable-next-line arrow-body-style
+  useEffect(() => {
+    return () => {
+      observer.current.teardown();
+      observer.current = null;
+    };
+  }, []);
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Convert react components to native Web Components that work with CanJS.",
   "main": "react-to-can-webcomponent",
   "dependencies": {
-    "can-observation": "^4.2.0"
+    "can-observation": "^4.2.0",
+    "can-observation-recorder": "^1.3.1",
+    "can-queues": "^1.3.1",
+    "can-reflect": "^1.18.0",
+    "ylem": "git+https://github.com/bitovi/ylem.git#hooks"
   },
   "devDependencies": {
     "@webcomponents/custom-elements": "^1.2.4",
@@ -12,7 +16,7 @@
     "can-observable-object": "^1.0.1",
     "can-stache": "^5.1.1",
     "can-stache-bindings": "^5.0.4",
-    "preact": "^8.5.3",
+    "preact": "^10.2.1",
     "preact-compat": "^3.19.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
@@ -30,6 +34,12 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "test": "testee --browsers firefox test.html"
+  },
+  "steal": {
+	  "map": {
+  		"preact/compat": "preact/compat/dist/compat",
+  		"preact/hooks": "preact/hooks/dist/hooks"
+  	}
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "can-stache": "^5.1.1",
     "can-stache-bindings": "^5.0.4",
     "preact": "^10.2.1",
-    "preact-compat": "^3.19.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -36,10 +35,10 @@
     "test": "testee --browsers firefox test.html"
   },
   "steal": {
-	  "map": {
-  		"preact/compat": "preact/compat/dist/compat",
-  		"preact/hooks": "preact/hooks/dist/hooks"
-  	}
+    "map": {
+      "preact/compat": "preact/compat/dist/compat",
+      "preact/hooks": "preact/hooks/dist/hooks"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This solves the issue with the demo of Todos changing incorrectly, and has been tested against its own unit battery as well as some real-world wrapped React components.  I endorse this as a complete solution for wrapping React components as web components and using Can observables.